### PR TITLE
fix: changed to `#sadd?` to avoid deprecation warnings

### DIFF
--- a/lib/redis/set.rb
+++ b/lib/redis/set.rb
@@ -23,7 +23,7 @@ class Redis
     # Add the specified value to the set only if it does not exist already.
     # Redis: SADD
     def add(value)
-      redis.sadd(key, to_redis(value))
+      redis.sadd?(key, to_redis(value))
     end
 
     # Remove and return a random member.  Redis: SPOP
@@ -34,7 +34,7 @@ class Redis
     # Adds the specified values to the set. Only works on redis > 2.4
     # Redis: SADD
     def merge(*values)
-      redis.sadd(key, values.flatten.map{|v| to_redis(v)})
+      redis.sadd?(key, values.flatten.map{|v| to_redis(v)})
     end
 
     # Return all members in the set.  Redis: SMEMBERS
@@ -49,12 +49,12 @@ class Redis
       redis.sismember(key, to_redis(value))
     end
     alias_method :include?, :member?
-    
+
     # Delete the value from the set.  Redis: SREM
     def delete(value)
       redis.srem(key, to_redis(value))
     end
-    
+
     # Delete if matches block
     def delete_if(&block)
       res = false
@@ -65,7 +65,7 @@ class Redis
       end
       res
     end
-    
+
     # Iterate through each member of the set.  Redis::Objects mixes in Enumerable,
     # so you can also use familiar methods like +collect+, +detect+, and so forth.
     def each(&block)
@@ -89,7 +89,7 @@ class Redis
     alias_method :intersect, :intersection
     alias_method :inter, :intersection
     alias_method :&, :intersection
-    
+
     # Calculate the intersection and store it in Redis as +name+. Returns the number
     # of elements in the stored intersection. Redis: SUNIONSTORE
     def interstore(name, *sets)
@@ -172,17 +172,17 @@ class Redis
     def ==(x)
       members == x
     end
-    
+
     def to_s
       members.join(', ')
     end
 
     private
-    
+
     def keys_from_objects(sets)
       raise ArgumentError, "Must pass in one or more set names" if sets.empty?
       sets.collect{|set| set.is_a?(Redis::Set) ? set.key : set}
     end
-    
+
   end
 end


### PR DESCRIPTION
## Description
During staging activity stream backfills following message was seen multiple times in logs
```
Redis#sadd will always return an Integer in Redis 5.0.0. Use Redis#sadd? instead.(called from: /app/vendor/bundle/ruby/3.3.0/bundler/gems/redis-objects-6e5969251b39/lib/redis/set.rb:26:in `add')
```
Which consumed the whole Papertrail plan in staging

These is the code used to backfill staging with activity stream data from postgres to redis
```ruby

    Event.event_occurred_at_gte(since).find_each do |event|
      ActivityStream::Observer.notify_create(event, disable_pusher: true)
    end
```